### PR TITLE
Don't assume unsuccessful response contains JSON

### DIFF
--- a/lib/omnikassa2.rb
+++ b/lib/omnikassa2.rb
@@ -1,6 +1,7 @@
 require 'openssl'
 require 'net/http'
 require 'base64'
+require 'json'
 
 require 'omnikassa2/version'
 
@@ -107,6 +108,9 @@ module Omnikassa2
   class ExpiringNotificationError < OmniKassaError
   end
 
-  class HttpError < OmniKassaError
+  # Inherits from JSON::ParserError for backwards compatibility:
+  # HTTP errors previously surfaced as JSON::ParserError when the
+  # non-JSON error response body was parsed.
+  class HttpError < JSON::ParserError
   end
 end


### PR DESCRIPTION
## what

Before this commit, when a 500 error happened at Rabobank, the body would still be parsed as JSON which led to ParserErrors.

This patch ensures that downstream checks for response.success? can do the right thing with an unsuccessful response (ie raise OmniKassa2::HttpError).

## Why

We're seeing `JSON::ParserError` when Rabobank serves errors. This should be more meaningful errors like e.g. `announce_order` already knows how to do:

```ruby
  def self.announce_order(order_announcement)
    response = Omnikassa2::OrderAnnounceRequest.new(order_announcement).send
    raise Omnikassa2::HttpError, response.to_s unless response.success?  # ← here
    ...
  end
```

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [X] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
