### PR TITLE
Fix empty orderResults serialization

### DIFF
--- a/lib/omnikassa2/helpers/csv_serializer.rb
+++ b/lib/omnikassa2/helpers/csv_serializer.rb
@@ -39,7 +39,8 @@ module Omnikassa2
       elsif nested_fields.nil?
         value
       else
-        CSVSerializer.new(nested_fields).serialize(value)
+        result = CSVSerializer.new(nested_fields).serialize(value)
+        result.empty? ? nil : result
       end
     end
 

--- a/spec/helpers/csv_serializer_spec.rb
+++ b/spec/helpers/csv_serializer_spec.rb
@@ -118,4 +118,23 @@ describe Omnikassa2::CSVSerializer do
 
     expect(csv_string).to eq('Hello World,123')
   end
+
+  it 'excludes empty nested arrays' do
+    exporter = Omnikassa2::CSVSerializer.new([
+      { field: :field_one },
+      {
+        field: :nested,
+        nested_fields: [
+          { field: :inner }
+        ]
+      }
+    ])
+
+    csv_string = exporter.serialize({
+      field_one: false,
+      nested: []
+    })
+
+    expect(csv_string).to eq('false')
+  end
 end


### PR DESCRIPTION
## What

Before this commit an empty collection is serialized to "". This should be nil as to not end up in the string used to verify the signature.

## Why

We saw signature failures - we established that it's because of empty result sets. When verifying the signature, it fails because the empty collection is serialised to an empty string - it should though be left out when verifying the signature.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
