### PR TITLE
Any connection error to Rabobank becomes Omnikassa2::HttpError

### DIFF
--- a/lib/omnikassa2/requests/base_request.rb
+++ b/lib/omnikassa2/requests/base_request.rb
@@ -1,3 +1,5 @@
+require 'net_http_timeout_errors'
+
 module Omnikassa2
   class BaseRequest
     def initialize(config = {})
@@ -45,6 +47,8 @@ module Omnikassa2
       end
 
       response_decorator.nil? ? http_response : response_decorator.new(http_response)
+    rescue *NetHttpTimeoutErrors.all => e
+      raise Omnikassa2::HttpError, "Request to Rabobank timed out: #{e.message}"
     end
 
     def headers

--- a/omnikassa2.gemspec
+++ b/omnikassa2.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
 
   # Ruby >= 3.4 compat: base64 no longer in stdlib
   spec.add_dependency "base64"
+  spec.add_dependency "net_http_timeout_errors"
 end


### PR DESCRIPTION
Followup on the discussion from recent PRs: this PR ensures that any connection error that happens when connecting to Rabobank is now wrapped in a `HttpError`.

## Why

There's a lot of Exceptions that can occur [when doing an HTTP connect](https://github.com/barsoom/net_http_timeout_errors/blob/058a87e8847470ce28f6fd268192c3a2dcdc6372/lib/net_http_timeout_errors.rb#L14-L35). These can all be considered `HttpError`s which we already use for unsuccessful requests.
`net_http_timeout_errors` is a tiny gem that collects all these exceptions such that we can handle them.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [x] Does the code **actually solve** the problem it was meant to solve?
* [x] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [x] Be kind.
