### PR TITLE
Deprecate warning to switch from JSON::ParserError=>HttpError

### DIFF
--- a/lib/omnikassa2.rb
+++ b/lib/omnikassa2.rb
@@ -112,5 +112,14 @@ module Omnikassa2
   # HTTP errors previously surfaced as JSON::ParserError when the
   # non-JSON error response body was parsed.
   class HttpError < JSON::ParserError
+    def initialize(message = nil)
+      super
+      warn <<~WARNING.split.join(" ")
+        DEPRECATION WARNING: Omnikassa2::HttpError currently inherits from JSON::ParserError
+        for backwards compatibility. In version 2.0, it will inherit from
+        Omnikassa2::OmniKassaError instead. Please update your rescue clauses to catch
+        Omnikassa2::HttpError explicitly.
+      WARNING
+    end
   end
 end

--- a/spec/omnikassa2_spec.rb
+++ b/spec/omnikassa2_spec.rb
@@ -47,6 +47,7 @@ describe Omnikassa2 do
         expect {
           Omnikassa2.announce_order(merchant_order)
         }.to raise_error(Omnikassa2::HttpError, /500.*Internal Server Error/m)
+         .and output(/DEPRECATION WARNING.*HttpError.*JSON::ParserError/m).to_stderr
       end
 
       it 'includes the HTML body in the error message' do


### PR DESCRIPTION
Recently the change was made to make `JSON::ParserError` the superclass of `Omnikassa2::HttpError`. This to not break callers handling `JSON::ParserError` or `HttpError`.

This deprecation warning allows us to change the hierarchy to what it was, which will break callers that currently only handle `JSON::ParserError` (and not `HttpError`).

## Why

Consumers can see upfront what will break.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
