### PR TITLE
Fix 2xx response without valid JSON

### DIFF
--- a/lib/omnikassa2/responses/base_response.rb
+++ b/lib/omnikassa2/responses/base_response.rb
@@ -16,13 +16,17 @@ module Omnikassa2
     private
 
     def parse_body
+      return nil unless http_success?
       return nil if @http_response.body.nil? || @http_response.body.empty?
-      return nil unless success?
 
       JSON.parse(@http_response.body)
     rescue JSON::ParserError
       # Response body is not valid JSON
       nil
+    end
+
+    def http_success?
+      code >= 200 && code < 300
     end
 
     public
@@ -36,18 +40,18 @@ module Omnikassa2
     end
 
     def success?
-      code >= 200 && code < 300
+      http_success? && !body.nil?
     end
 
     def to_s
       value = "Status: #{code}: #{message}\n"
       if body
         value += "Body: #{body}"
-      elsif @http_response.body
-        # Show (part of) raw body for error responses (may be HTML)
-        value += "Body: #{@http_response.body.to_s[0, 500]}"
+      elsif @http_response.body && !@http_response.body.empty?
+        # Show (part of) raw body for error responses (may be HTML or invalid JSON)
+        value += "Body (unparseable): #{@http_response.body.to_s[0, 500]}"
       else
-        value += "Body: nil"
+        value += "Body: empty"
       end
       value
     end


### PR DESCRIPTION
Before this commit a response was considered successful iff its http status was 2xx. This doesn't handle cases (we ran into) where such responses contain invalid JSON (that with the recent fixes would result in `body.nil?`). This commit makes response.success? stricter such that HttpError's are raised when parse_body returns nil.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
