### PR TITLE
Backwards compatibiliy for 1.x release

### DIFF
--- a/lib/omnikassa2/helpers/access_token_provider.rb
+++ b/lib/omnikassa2/helpers/access_token_provider.rb
@@ -26,7 +26,7 @@ module Omnikassa2
 
     def refresh_token
       response = Omnikassa2::RefreshRequest.new.send
-      raise Omnikassa2::HttpError, response.to_s unless response.success?
+      raise response.error_class, response.to_s unless response.success?
 
       @access_token = response.access_token
     end

--- a/lib/omnikassa2/responses/base_response.rb
+++ b/lib/omnikassa2/responses/base_response.rb
@@ -16,7 +16,6 @@ module Omnikassa2
     private
 
     def parse_body
-      return nil unless http_success?
       return nil if @http_response.body.nil? || @http_response.body.empty?
 
       JSON.parse(@http_response.body)
@@ -25,11 +24,20 @@ module Omnikassa2
       nil
     end
 
+    public
+
     def http_success?
       code >= 200 && code < 300
     end
 
-    public
+    # Returns the appropriate error class based on response state
+    def error_class
+      if !http_success? && body
+        Omnikassa2::ApiError
+      else
+        Omnikassa2::HttpError
+      end
+    end
 
     def code
       @http_response.code.to_i

--- a/spec/omnikassa2_spec.rb
+++ b/spec/omnikassa2_spec.rb
@@ -56,6 +56,40 @@ describe Omnikassa2 do
       end
     end
 
+    context 'when API returns 400 with JSON error body' do
+      before do
+        WebMock.stub_request(:get, "https://www.example.org/sandbox/gatekeeper/refresh")
+          .to_return(
+            status: 200,
+            body: {
+              token: 'myAccEssT0ken',
+              validUntil: "2099-12-31T23:59:59.999+0000",
+              durationInMillis: 28800000
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        WebMock.stub_request(:post, "https://www.example.org/sandbox/order/server/api/order")
+          .to_return(
+            status: 400,
+            body: { errorCode: 'INVALID_REQUEST', message: 'Invalid merchant order' }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'raises ApiError (subclass of OmniKassaError)' do
+        expect {
+          Omnikassa2.announce_order(merchant_order)
+        }.to raise_error(Omnikassa2::ApiError)
+      end
+
+      it 'is catchable via OmniKassaError' do
+        expect {
+          Omnikassa2.announce_order(merchant_order)
+        }.to raise_error(Omnikassa2::OmniKassaError)
+      end
+    end
+
     context 'when API returns 200 with empty body' do
       before do
         WebMock.stub_request(:get, "https://www.example.org/sandbox/gatekeeper/refresh")


### PR DESCRIPTION
Before this commit when handling OmniKassa2::OmnikassaError it might have handled Omnikassa2::HttpError's.
This might have been the (unlikely) case where there's an unsuccessful response containing valid JSON.
With HttpError no longer inheriting from OmnikassaError this would break. Now ApiError takes it place until 2.0.

A deprecation warning is shown (also to those handling JSON::ParserError) to migrate to HttpError or OmnikassaError before 2.0.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
